### PR TITLE
Update C++ code to resolve issues 20, 34-36

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^README\.Rmd$
 ^tests/testthat/test_gcalibrateC\.R$
 ^man/figures
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 .DS_Store
+.vscode/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: agcounts
 Type: Package
 Title: Calculate 'ActiGraph' Counts from Accelerometer Data
-Version: 0.6.7
+Version: 0.6.8
 Authors@R: c(
     person(c("Brian", "C."), "Helsel", email = "bhelsel@kumc.edu", role = c("aut", "cre")),
     person(c("Paul", "R."), "Hibbing", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# agcounts 0.6.8
+* Fix issue #20 related to C++ compiling by adding the `Rcpp` plugin for C++ 11.
+* Update C++ code for `gcalibrateC` to resolve issue when there are NaN values in sphere data (issue #35)
+* Resolve issue #36 when `calErrorEnd` never gets below 0.01.
+* Change minloadcrit from 72 to 168 as recommended in issue #34
+
 # agcounts 0.6.7
 * Update `agcalibrate` to speed up function by first converting to a `data.table` before merging with the time stamps.
 * Add parameter `imputeTimeGaps` to `agcalibrate` for users to decide if zeros are added back after calibration.

--- a/src/gcalibrate.cpp
+++ b/src/gcalibrate.cpp
@@ -1,3 +1,4 @@
+// [[Rcpp::plugins(cpp11)]]
 #include <RcppArmadillo.h>
 #include <iostream>
 #include <vector>
@@ -91,7 +92,7 @@ Rcpp::List gcalibrateC(Rcpp::Nullable<Rcpp::String> pathname = R_NilValue, Rcpp:
   }
 
   Rcpp::NumericVector ws {5, 900, 3600};
-  int startpage, endpage, blocksize = 12 * ws(2), minloadcrit = 72;
+  int startpage, endpage, blocksize = 12 * ws(2), minloadcrit = 168;
   double NR = ceil((90*pow(10, 6)) / (sf*10)) + 1000; // NR = number of '10' second rows (this is for 10 days at 80 Hz)
   int count = 0; // counter to keep track of the number of seconds that have been read
   double spherecrit = 0.3, sdcriter = 0.013;
@@ -162,7 +163,8 @@ Rcpp::List gcalibrateC(Rcpp::Nullable<Rcpp::String> pathname = R_NilValue, Rcpp:
     if((use > 0) && (use != LD)){
       S = data(Rcpp::Range(use, LD-1), Rcpp::_);
     }
-    data = data(Rcpp::Range(0, use-1), Rcpp::_);
+
+    if(use != 0) data = data(Rcpp::Range(0, use-1), Rcpp::_);    
 
     if(data.nrow() < blocksize * 30){
       LD = 0;
@@ -274,7 +276,9 @@ Rcpp::List gcalibrateC(Rcpp::Nullable<Rcpp::String> pathname = R_NilValue, Rcpp:
 
         for(int i = 0; i < input.nrow(); i++){
           for(int j = 0; j < input.ncol(); j++){
-            closestpoint(i, j) = curr(i, j) / sqrt(rsum[i]);
+            if(curr(i, j) != 0){
+              closestpoint(i, j) = curr(i, j) / sqrt(rsum[i]);
+            }
           }
         }
 
@@ -311,6 +315,7 @@ Rcpp::List gcalibrateC(Rcpp::Nullable<Rcpp::String> pathname = R_NilValue, Rcpp:
 
       if((calErrorEnd < calErrorStart) && (calErrorEnd < 0.01) && (nhoursused > minloadcrit)){
         LD = 0;
+        Rcpp::Rcout << "Recalibration done, no problems detected";
       }
     }
       i += 1;

--- a/src/resample_helpers.cpp
+++ b/src/resample_helpers.cpp
@@ -1,3 +1,4 @@
+// [[Rcpp::plugins(cpp11)]]
 #include <Rcpp.h>
 using namespace Rcpp;
 


### PR DESCRIPTION
# agcounts 0.6.8
* Resolves #20 related to C++ compiling by adding the `Rcpp` plugin for C++ 11.
* Update C++ code for `gcalibrateC` to resolve issue when there are NaN values in sphere data (fixes #35)
* Resolves #36 when `calErrorEnd` never gets below 0.01.
* Change minloadcrit from 72 to 168 as recommended to resolve #34